### PR TITLE
[#4] 백엔드 API 경로를 https로 변경

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,3 +1,3 @@
 class Config {
-  static const String apiUrl = "http://dev.wedding-jira.com/api/v1";
+  static const String apiUrl = "https://dev.wedding-jira.com/api/v1";
 }


### PR DESCRIPTION
Issue #4
```
Mixed Content: The page at 'https://wedding-jira.vercel.app/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://dev.wedding-jira.com/api/v1/auth/login'. This request has been blocked; the content must be served over HTTPS.
```
크롬 정책상 https는 https 에서 온 요청만 처리할 수 있으므로 백엔드 API를 https로 변경함